### PR TITLE
fix socks bug

### DIFF
--- a/internal/socks/socks.go
+++ b/internal/socks/socks.go
@@ -113,6 +113,13 @@ func (s *SOCKS5Server) createProxyConnection(transport string, addr string) (net
 		return nil, fmt.Errorf("failed to create new connection: %v", err)
 	}
 
+	// If the connection is nil, it means that the data channel could not be created.
+	// This can happen if the relay is not responding or if the data channel is not
+	// yet open. In this case, we should return an error to the SOCKS5 client.
+	if connection == nil {
+		return nil, fmt.Errorf("failed to create new connection: connection is nil")
+	}
+
 	req := connectionDetails{
 		NetworkType: transport,
 		TargetAddr:  addr,


### PR DESCRIPTION
  This PR introduces a nil check in internal/socks/socks.go immediately after the call to s.newConnection.

  If s.newConnection returns a nil connection, the function now immediately returns an error to the SOCKS5
  dialer. This prevents the panic and allows the SOCKS5 server to gracefully handle the failed connection
  attempt while remaining operational. The client that initiated the request will receive a standard
  connection error, and the controller process will no longer crash.